### PR TITLE
Triggers Observers after Loading StoryState

### DIFF
--- a/ink-engine-runtime/VariablesState.cs
+++ b/ink-engine-runtime/VariablesState.cs
@@ -137,7 +137,7 @@ namespace Ink.Runtime
             foreach (var varVal in _defaultGlobalVariables) {
                 object loadedToken;
                 if( jToken.TryGetValue(varVal.Key, out loadedToken) ) {
-                    _globalVariables[varVal.Key] = Json.JTokenToRuntimeObject(loadedToken);
+                    SetGlobal(varVal.Key, Json.JTokenToRuntimeObject(loadedToken));
                 } else {
                     _globalVariables[varVal.Key] = varVal.Value;
                 }


### PR DESCRIPTION
Had an issue where after Loading StoryState with state.LoadJson, none of the variableObservers would trigger, found that when using SetJsonToken it doesn't use SetGlobal() that will trigger check and notify any varaible observers of change.